### PR TITLE
Kotlin 1.1.2対応のコードを追加

### DIFF
--- a/Kotlin/WebDemo/v_1_1_2/KolinEnumSample.kt
+++ b/Kotlin/WebDemo/v_1_1_2/KolinEnumSample.kt
@@ -1,0 +1,89 @@
+package v_1_1_2
+
+
+fun main(args: Array<String>) {
+
+
+    //==============================================
+    // enumの持つ基本的なメソッド
+    //==============================================  
+
+    println(Direction.NORTH.name)
+    println(Direction.NORTH.toString())
+    println(Direction.SOUTH.ordinal)
+    println(Direction.SOUTH.compareTo(Direction.NORTH))
+    println(Direction.SOUTH == Direction.NORTH)
+
+
+    //==============================================
+    // whenでパターンマッチ
+    //==============================================
+    val d = Direction.SOUTH
+    when (d) {
+        Direction.NORTH -> println("north")
+        Direction.SOUTH -> println("south")
+        Direction.WEST -> println("west")
+        Direction.EAST -> println("east")
+    }
+
+    //==============================================
+    // Stateパターン
+    //==============================================
+
+    println(ProtocolState.WAITING.signal().signal().signal().signal())
+
+    //==============================================
+    // プロパティを持つenum
+    //==============================================
+
+    println(Color.RED.rgb)
+
+    //==============================================
+    // Kotlin lambda
+    //==============================================
+    Yen.values().filter { it.price > 100 }.forEach { println(it) }
+
+    //==============================================
+    // Java lambda
+    //==============================================
+    //Stream.of(Yen.values()).filter(x -> x.getPrice() > 100).forEach(System.out::println);
+
+}
+
+
+//==============================================
+// enum
+//==============================================
+
+enum class Color(val rgb: Int) {
+    RED(0xFF0000),
+    GREEN(0x00FF00),
+    BLUE(0x0000FF)
+}
+
+enum class Yen(val price: Int) {
+    十円硬貨(10),
+    百円硬貨(100),
+    千円札(1000),
+    一万円札(10000)
+}
+
+
+enum class ProtocolState {
+    WAITING {
+        override fun signal() = TALKING
+    },
+
+    TALKING {
+        override fun signal() = WAITING
+    };
+
+    abstract fun signal(): ProtocolState
+}
+
+enum class Direction {
+    NORTH,
+    SOUTH,
+    WEST,
+    EAST
+}

--- a/Kotlin/WebDemo/v_m8/KolinEnumSample.kt
+++ b/Kotlin/WebDemo/v_m8/KolinEnumSample.kt
@@ -1,3 +1,4 @@
+package v_m8
 
 
 

--- a/Kotlin/WebDemo/v_m8/Tests.kt
+++ b/Kotlin/WebDemo/v_m8/Tests.kt
@@ -1,3 +1,5 @@
+package v_m8
+
 fun runs(a: IntArray): Int {
   return a.answer({(i: Int): Boolean -> i + 1 < a.size && a.get(i) != a.get(i + 1) })
 }


### PR DESCRIPTION
#2 での指摘を受けて、再度PRさせていただきます (却下していただいても構いません)。

<内容>
* コードをKotlin 1.1.2に対応 (Kotlin M8のバックアップあり)
   * Enumクラスのnameやoriginalを属性として扱うように変更
   * Enumクラスのequalsメソッドは==演算子を用いた場合に呼び出されるので、equalsメソッドを明示的に呼び出している部分を削除
   * when句において、Directionクラスの全ての要素について処理が書かれている (IntelliJ IDEAにて確認済み) ため、elseを削除
   * Enumクラスの記述方法をKotlin 1.1.2に対応